### PR TITLE
DEV: Remove bootbox.alert call

### DIFF
--- a/assets/javascripts/widgets/discourse-survey.js.es6
+++ b/assets/javascripts/widgets/discourse-survey.js.es6
@@ -522,13 +522,7 @@ export default createWidget("discourse-survey", {
       .then(() => {
         state.submitted = true;
       })
-      .catch((error) => {
-        if (error) {
-          popupAjaxError(error);
-        } else {
-          bootbox.alert(I18n.t("survey.error_while_casting_votes"));
-        }
-      })
+      .catch(popupAjaxError)
       .finally(() => {
         state.loading = false;
       });


### PR DESCRIPTION
The `error_while_casting_votes` string isn't defined anyway, so we can just call `popupAjaxError` without a parameter and it will handle both cases.