### PR TITLE
DEV: Pass respect_plugin_enabled to add_to_serializer as keyword argument

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -103,7 +103,7 @@ after_initialize do
       end
   end
 
-  add_to_serializer(:post, :preloaded_surveys, false) do
+  add_to_serializer(:post, :preloaded_surveys, respect_plugin_enabled: false) do
     @preloaded_surveys ||=
       if @topic_view.present?
         @topic_view.surveys[object.id]
@@ -114,7 +114,7 @@ after_initialize do
 
   add_to_serializer(:post, :include_preloaded_surveys?) { false }
 
-  add_to_serializer(:post, :surveys, false) do
+  add_to_serializer(:post, :surveys, respect_plugin_enabled: false) do
     preloaded_surveys.map { |s| SurveySerializer.new(s, root: false, scope: self.scope) }
   end
 


### PR DESCRIPTION
### What is this change?

Passing the `respect_plugin_enabled` argument to `#add_to_serializer` as a positional argument is deprecated. It is now expected to be a keyword argument. This PR adds the keyword.