### PR TITLE
DEV: update deprecated icon name in stylesheet

### DIFF
--- a/assets/stylesheets/common/survey.scss
+++ b/assets/stylesheets/common/survey.scss
@@ -40,8 +40,8 @@
     padding: 0.25em 0;
     word-break: break-word;
 
-    .d-icon-far-check-circle,
-    .d-icon-far-check-square {
+    .d-icon-far-circle-check,
+    .d-icon-far-square-check {
       color: var(--tertiary);
     }
   }
@@ -158,7 +158,7 @@
     font-size: $font-up-1;
     padding: 0.25em 0.5em;
 
-    .d-icon-far-check-circle {
+    .d-icon-far-circle-check {
       margin-right: 0.25em;
       color: var(--success);
     }


### PR DESCRIPTION
This PR updates deprecated Font Awesome icon names in the stylesheet. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.