### PR TITLE
FIX: allow staff to edit surveys after post ownership transfer

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -8,6 +8,7 @@ en:
       no_responses: "No responses yet"
       username: "Username"
       email: "Email"
+    insufficient_rights_to_create: "You don't have permission to create or edit a survey."
     post_survey_exists: "There is a survey associated already with this post."
     user_already_responded: "You have already responded to this survey."
     max_one_survey_per_post: "Only one survey is allowed in a post."

--- a/lib/discourse_surveys/post_validator.rb
+++ b/lib/discourse_surveys/post_validator.rb
@@ -7,7 +7,8 @@ module DiscourseSurveys
     end
 
     def validate_post
-      if @post&.user&.staff? || @post&.topic&.pm_with_non_human_user?
+      acting_user = @post&.acting_user || @post&.user
+      if acting_user&.staff? || @post&.topic&.pm_with_non_human_user?
         true
       else
         @post.errors.add(:base, I18n.t("survey.insufficient_rights_to_create"))

--- a/spec/lib/post_validator_spec.rb
+++ b/spec/lib/post_validator_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+describe DiscourseSurveys::PostValidator do
+  before { SiteSetting.surveys_enabled = true }
+
+  let(:survey_raw) { <<~MD }
+      [survey name="test"]
+      [radio question="Pick one:"]
+      - A
+      - B
+      [/radio]
+      [/survey]
+    MD
+
+  describe "#validate_post" do
+    fab!(:staff) { Fabricate(:admin) }
+    fab!(:user)
+
+    it "allows creation when the post author is staff" do
+      post = Fabricate(:post, user: staff, raw: survey_raw)
+      expect(post).to be_valid
+    end
+
+    it "rejects creation when the post author is not staff" do
+      post = Fabricate.build(:post, user: user, raw: survey_raw)
+      expect(post).not_to be_valid
+      expect(post.errors[:base]).to include(I18n.t("survey.insufficient_rights_to_create"))
+    end
+
+    it "renders a real translation (no missing-translation fallback)" do
+      post = Fabricate.build(:post, user: user, raw: survey_raw)
+      post.valid?
+      expect(post.errors[:base].join).not_to include("translation missing")
+      expect(post.errors[:base].join).not_to include("Translation missing")
+    end
+
+    it "allows staff to edit a survey on a post owned by a non-staff user" do
+      post = Fabricate(:post, user: staff, raw: survey_raw)
+      PostOwnerChanger.new(
+        post_ids: [post.id],
+        topic_id: post.topic_id,
+        new_owner: user,
+        acting_user: staff,
+      ).change_owner!
+      post.reload
+
+      revisor = PostRevisor.new(post)
+      result =
+        revisor.revise!(
+          staff,
+          { raw: survey_raw + "\nedited by staff" },
+          force_new_version: true,
+        )
+
+      expect(result).to eq(true)
+      expect(post.errors[:base]).to be_empty
+    end
+
+    it "rejects edits by a non-staff user on a post they own after transfer" do
+      post = Fabricate(:post, user: staff, raw: survey_raw)
+      PostOwnerChanger.new(
+        post_ids: [post.id],
+        topic_id: post.topic_id,
+        new_owner: user,
+        acting_user: staff,
+      ).change_owner!
+      post.reload
+
+      revisor = PostRevisor.new(post)
+      result =
+        revisor.revise!(user, { raw: survey_raw + "\nedited by user" }, force_new_version: true)
+
+      expect(result).to eq(false)
+      expect(post.errors[:base]).to include(I18n.t("survey.insufficient_rights_to_create"))
+    end
+  end
+end

--- a/spec/lib/post_validator_spec.rb
+++ b/spec/lib/post_validator_spec.rb
@@ -3,75 +3,56 @@
 describe DiscourseSurveys::PostValidator do
   before { SiteSetting.surveys_enabled = true }
 
-  let(:survey_raw) { <<~MD }
-      [survey name="test"]
-      [radio question="Pick one:"]
-      - A
-      - B
-      [/radio]
-      [/survey]
-    MD
+  fab!(:staff, :admin)
+  fab!(:user)
+  fab!(:topic)
+  fab!(:post) { Fabricate(:post, topic: topic, user: user) }
 
   describe "#validate_post" do
-    fab!(:staff) { Fabricate(:admin) }
-    fab!(:user)
-
-    it "allows creation when the post author is staff" do
-      post = Fabricate(:post, user: staff, raw: survey_raw)
-      expect(post).to be_valid
+    it "passes when the acting user is staff" do
+      post.acting_user = staff
+      expect(described_class.new(post).validate_post).to eq(true)
+      expect(post.errors[:base]).to be_empty
     end
 
-    it "rejects creation when the post author is not staff" do
-      post = Fabricate.build(:post, user: user, raw: survey_raw)
-      expect(post).not_to be_valid
+    it "fails when the acting user is not staff" do
+      post.acting_user = user
+      expect(described_class.new(post).validate_post).to eq(false)
       expect(post.errors[:base]).to include(I18n.t("survey.insufficient_rights_to_create"))
     end
 
     it "renders a real translation (no missing-translation fallback)" do
-      post = Fabricate.build(:post, user: user, raw: survey_raw)
-      post.valid?
-      expect(post.errors[:base].join).not_to include("translation missing")
-      expect(post.errors[:base].join).not_to include("Translation missing")
+      post.acting_user = user
+      described_class.new(post).validate_post
+      expect(post.errors[:base].join.downcase).not_to include("translation missing")
     end
 
-    it "allows staff to edit a survey on a post owned by a non-staff user" do
-      post = Fabricate(:post, user: staff, raw: survey_raw)
-      PostOwnerChanger.new(
-        post_ids: [post.id],
-        topic_id: post.topic_id,
-        new_owner: user,
-        acting_user: staff,
-      ).change_owner!
-      post.reload
+    it "passes when staff edits a post owned by a non-staff user" do
+      post.acting_user = staff
+      expect(post.user).to eq(user)
+      expect(described_class.new(post).validate_post).to eq(true)
+    end
 
-      revisor = PostRevisor.new(post)
-      result =
-        revisor.revise!(
-          staff,
-          { raw: survey_raw + "\nedited by staff" },
-          force_new_version: true,
+    it "falls back to post.user when acting_user is not set (e.g. background jobs)" do
+      staff_post = Fabricate(:post, user: staff)
+      staff_post.acting_user = nil
+      expect(described_class.new(staff_post).validate_post).to eq(true)
+    end
+
+    it "passes for posts in PMs with a non-human user even without staff" do
+      bot = Discourse.system_user
+      pm_topic =
+        Fabricate(
+          :private_message_topic,
+          topic_allowed_users: [
+            Fabricate.build(:topic_allowed_user, user: user),
+            Fabricate.build(:topic_allowed_user, user: bot),
+          ],
         )
+      pm_post = Fabricate(:post, topic: pm_topic, user: user)
+      pm_post.acting_user = user
 
-      expect(result).to eq(true)
-      expect(post.errors[:base]).to be_empty
-    end
-
-    it "rejects edits by a non-staff user on a post they own after transfer" do
-      post = Fabricate(:post, user: staff, raw: survey_raw)
-      PostOwnerChanger.new(
-        post_ids: [post.id],
-        topic_id: post.topic_id,
-        new_owner: user,
-        acting_user: staff,
-      ).change_owner!
-      post.reload
-
-      revisor = PostRevisor.new(post)
-      result =
-        revisor.revise!(user, { raw: survey_raw + "\nedited by user" }, force_new_version: true)
-
-      expect(result).to eq(false)
-      expect(post.errors[:base]).to include(I18n.t("survey.insufficient_rights_to_create"))
+      expect(described_class.new(pm_post).validate_post).to eq(true)
     end
   end
 end


### PR DESCRIPTION
The post validator checked the post **owner** (`@post.user.staff?`) instead of the user performing the edit. After ownership transfer to a non-staff user, even staff editors were blocked, and they saw a raw `Translation missing: en.survey.insufficient_rights_to_create` because that key was missing from `server.en.yml`.

**Changes:**

- Validate `@post.acting_user` (falls back to `@post.user` on create).
- Add the missing `survey.insufficient_rights_to_create` translation.
- Add specs covering create permissions and edits across ownership transfers.