### PR TITLE
FEATURE: add site setting to control which groups can create surveys

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,6 +1,7 @@
 en:
   site_settings:
     surveys_enabled: "Enable Surveys plugin"
+    surveys_allowed_groups: "Groups whose members are allowed to create surveys."
 
   survey:
     survey: "survey"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,3 +2,8 @@ plugins:
   surveys_enabled:
     default: false
     client: true
+  surveys_allowed_groups:
+    default: "3"
+    type: group_list
+    allow_any: false
+    refresh: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,7 +3,7 @@ plugins:
     default: false
     client: true
   surveys_allowed_groups:
-    default: "3"
+    default: "3" # auto group staff
     type: group_list
     allow_any: false
     refresh: true

--- a/lib/discourse_surveys/post_validator.rb
+++ b/lib/discourse_surveys/post_validator.rb
@@ -8,7 +8,11 @@ module DiscourseSurveys
 
     def validate_post
       acting_user = @post&.acting_user || @post&.user
-      if acting_user&.staff? || @post&.topic&.pm_with_non_human_user?
+      allowed =
+        acting_user.present? &&
+          (acting_user.admin? || acting_user.in_any_groups?(SiteSetting.surveys_allowed_groups_map))
+
+      if allowed
         true
       else
         @post.errors.add(:base, I18n.t("survey.insufficient_rights_to_create"))

--- a/spec/lib/post_validator_spec.rb
+++ b/spec/lib/post_validator_spec.rb
@@ -4,6 +4,7 @@ describe DiscourseSurveys::PostValidator do
   before { SiteSetting.surveys_enabled = true }
 
   fab!(:staff, :admin)
+  fab!(:moderator)
   fab!(:user)
   fab!(:topic)
   fab!(:post) { Fabricate(:post, topic: topic, user: user) }
@@ -19,6 +20,29 @@ describe DiscourseSurveys::PostValidator do
       post.acting_user = user
       expect(described_class.new(post).validate_post).to eq(false)
       expect(post.errors[:base]).to include(I18n.t("survey.insufficient_rights_to_create"))
+    end
+
+    it "passes when the acting user belongs to one of the allowed groups" do
+      group = Fabricate(:group)
+      group.add(user)
+      SiteSetting.surveys_allowed_groups = "#{Group::AUTO_GROUPS[:staff]}|#{group.id}"
+      post.acting_user = user
+      expect(described_class.new(post).validate_post).to eq(true)
+      expect(post.errors[:base]).to be_empty
+    end
+
+    it "fails when a non-admin staff member is not in any allowed group" do
+      SiteSetting.surveys_allowed_groups = ""
+      post.acting_user = moderator
+      expect(described_class.new(post).validate_post).to eq(false)
+      expect(post.errors[:base]).to include(I18n.t("survey.insufficient_rights_to_create"))
+    end
+
+    it "always allows admin users regardless of the allowed groups setting" do
+      SiteSetting.surveys_allowed_groups = ""
+      post.acting_user = staff
+      expect(described_class.new(post).validate_post).to eq(true)
+      expect(post.errors[:base]).to be_empty
     end
 
     it "renders a real translation (no missing-translation fallback)" do
@@ -37,22 +61,6 @@ describe DiscourseSurveys::PostValidator do
       staff_post = Fabricate(:post, user: staff)
       staff_post.acting_user = nil
       expect(described_class.new(staff_post).validate_post).to eq(true)
-    end
-
-    it "passes for posts in PMs with a non-human user even without staff" do
-      bot = Discourse.system_user
-      pm_topic =
-        Fabricate(
-          :private_message_topic,
-          topic_allowed_users: [
-            Fabricate.build(:topic_allowed_user, user: user),
-            Fabricate.build(:topic_allowed_user, user: bot),
-          ],
-        )
-      pm_post = Fabricate(:post, topic: pm_topic, user: user)
-      pm_post.acting_user = user
-
-      expect(described_class.new(pm_post).validate_post).to eq(true)
     end
   end
 end


### PR DESCRIPTION
Adds a new `surveys_allowed_groups` site setting (`group_list`, default `staff` auto group) that determines which user groups are permitted to create or edit surveys. Previously the check was hardcoded to staff.

- Replaces the `acting_user.staff?` check in `PostValidator` with a group-based check using `SiteSetting.surveys_allowed_groups_map`.
- Admins always bypass the setting so they cannot lock themselves out by narrowing the allowed groups.
- Removes the legacy "PM with a non-human user" exception, which is not used by any survey flow.
- Defaults match prior behavior for staff so existing sites are unaffected on upgrade.