### PR TITLE
FIX: implement number field min/max range and validate submitted values

### DIFF
--- a/app/models/survey_field.rb
+++ b/app/models/survey_field.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class SurveyField < ActiveRecord::Base
+  DEFAULT_NUMBER_MIN = 1
+  DEFAULT_NUMBER_MAX = 10
+
   has_many :survey_field_options, -> { order(:id) }, dependent: :destroy
   has_many :survey_responses, dependent: :destroy
   belongs_to :survey
@@ -21,6 +24,18 @@ class SurveyField < ActiveRecord::Base
   def is_multiple_choice?
     response_type == SurveyField.response_type[:checkbox]
   end
+
+  def is_number?
+    response_type == SurveyField.response_type[:number]
+  end
+
+  def number_min
+    min || DEFAULT_NUMBER_MIN
+  end
+
+  def number_max
+    max || DEFAULT_NUMBER_MAX
+  end
 end
 
 # == Schema Information
@@ -37,6 +52,8 @@ end
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  survey_id         :bigint
+#  min               :integer
+#  max               :integer
 #
 # Indexes
 #

--- a/app/serializers/survey_field_serializer.rb
+++ b/app/serializers/survey_field_serializer.rb
@@ -16,22 +16,6 @@ class SurveyFieldSerializer < ApplicationSerializer
     object.survey_field_options.map { |o| SurveyFieldOptionSerializer.new(o, root: false).as_json }
   end
 
-  def min
-    object.number_min
-  end
-
-  def include_min?
-    object.is_number?
-  end
-
-  def max
-    object.number_max
-  end
-
-  def include_max?
-    object.is_number?
-  end
-
   def has_options
     object.has_options?
   end

--- a/app/serializers/survey_field_serializer.rb
+++ b/app/serializers/survey_field_serializer.rb
@@ -8,10 +8,28 @@ class SurveyFieldSerializer < ApplicationSerializer
              :field_class,
              :options,
              :has_options,
-             :is_multiple_choice
+             :is_multiple_choice,
+             :min,
+             :max
 
   def options
     object.survey_field_options.map { |o| SurveyFieldOptionSerializer.new(o, root: false).as_json }
+  end
+
+  def min
+    object.number_min
+  end
+
+  def include_min?
+    object.is_number?
+  end
+
+  def max
+    object.number_max
+  end
+
+  def include_max?
+    object.is_number?
   end
 
   def has_options

--- a/assets/javascripts/components/surveys/fields/number.gjs
+++ b/assets/javascripts/components/surveys/fields/number.gjs
@@ -5,9 +5,23 @@ import { action } from "@ember/object";
 import icon from "discourse/helpers/d-icon";
 import { bind } from "discourse/lib/decorators";
 
-const NUMBERS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+const DEFAULT_MIN = 1;
+const DEFAULT_MAX = 10;
 
 export default class SurveyNumber extends Component {
+  get numbers() {
+    const min = parseInt(this.args.field.min, 10);
+    const max = parseInt(this.args.field.max, 10);
+    const start = Number.isNaN(min) ? DEFAULT_MIN : min;
+    const end = Number.isNaN(max) ? DEFAULT_MAX : max;
+
+    const numbers = [];
+    for (let value = start; value <= end; value++) {
+      numbers.push(value);
+    }
+    return numbers;
+  }
+
   @action
   toggle(value) {
     this.args.toggleValue({
@@ -25,7 +39,7 @@ export default class SurveyNumber extends Component {
 
   <template>
     {{! template-lint-disable no-invalid-interactive }}
-    {{#each NUMBERS as |value|}}
+    {{#each this.numbers as |value|}}
       <li class="survey-field-number" {{on "click" (fn this.toggle value)}}>
         {{icon (this.iconFor value)}}
         <span>{{value}}</span>

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -22,3 +22,4 @@ en:
     field_is_required: "The field '%{question}' is required."
     invalid_option: "Invalid option for field '%{question}'."
     invalid_number: "The value for field '%{question}' must be a number between %{min} and %{max}."
+    number_field_invalid_range: "Number fields must use whole number values with a maximum range of %{count} options."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -21,3 +21,4 @@ en:
     user_cant_post_in_topic: "You don't have permission to post in this topic."
     field_is_required: "The field '%{question}' is required."
     invalid_option: "Invalid option for field '%{question}'."
+    invalid_number: "The value for field '%{question}' must be a number between %{min} and %{max}."

--- a/db/migrate/20260608000000_add_min_max_to_survey_fields.rb
+++ b/db/migrate/20260608000000_add_min_max_to_survey_fields.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddMinMaxToSurveyFields < ActiveRecord::Migration[7.2]
+  def change
+    add_column :survey_fields, :min, :integer, default: nil
+    add_column :survey_fields, :max, :integer, default: nil
+  end
+end

--- a/lib/discourse_surveys/helper.rb
+++ b/lib/discourse_surveys/helper.rb
@@ -56,6 +56,8 @@ module DiscourseSurveys
                     SurveyField.response_type[:radio],
                 response_required: field["required"].presence || true,
                 field_class: field["class"].presence,
+                min: field["min"].presence,
+                max: field["max"].presence,
               )
 
             if field["options"].present?
@@ -134,6 +136,20 @@ module DiscourseSurveys
                                                 question: field.question,
                                               )
                     end
+
+                    if value.present? && field.is_number?
+                      number = Integer(value.to_s, 10, exception: false)
+                      if number.nil? || number < field.number_min || number > field.number_max
+                        raise StandardError.new I18n.t(
+                                                  "survey.invalid_number",
+                                                  question: field.question,
+                                                  min: field.number_min,
+                                                  max: field.number_max,
+                                                )
+                      end
+                      value = number.to_s
+                    end
+
                     obj[field.id] = { value: value, has_options: false }
                   end
                 elsif field.response_required

--- a/lib/discourse_surveys/survey_updater.rb
+++ b/lib/discourse_surveys/survey_updater.rb
@@ -66,6 +66,8 @@ module DiscourseSurveys
                     SurveyField.response_type[field["type"].to_sym] ||
                       SurveyField.response_type[:radio],
                   field_class: field["class"].presence,
+                  min: field["min"].presence,
+                  max: field["max"].presence,
                 )
 
               if field["options"].present?
@@ -94,6 +96,8 @@ module DiscourseSurveys
             old_field["position"] = new_field["position"]
             old_field["response_required"] = new_field["required"].presence || true
             old_field["field_class"] = new_field["class"].presence
+            old_field["min"] = new_field["min"].presence
+            old_field["max"] = new_field["max"].presence
             old_field.save!
 
             # update field attributes
@@ -113,6 +117,8 @@ module DiscourseSurveys
                     SurveyField.response_type[new_field["type"].to_sym] ||
                       SurveyField.response_type[:radio],
                   field_class: new_field["class"].presence,
+                  min: new_field["min"].presence,
+                  max: new_field["max"].presence,
                 )
 
               if new_field["options"].present?

--- a/lib/discourse_surveys/survey_validator.rb
+++ b/lib/discourse_surveys/survey_validator.rb
@@ -3,6 +3,7 @@
 module DiscourseSurveys
   class SurveyValidator
     MAX_VALUE = 2_147_483_647
+    MAX_NUMBER_OPTIONS = 100
 
     def initialize(post)
       @post = post
@@ -17,6 +18,7 @@ module DiscourseSurveys
         .each do |survey|
           return false unless unique_questions?(survey)
           return false unless any_blank_questions?(survey)
+          return false unless valid_number_ranges?(survey)
           surveys["survey"] = survey
           survey_count += 1
         end
@@ -47,6 +49,33 @@ module DiscourseSurveys
       end
 
       true
+    end
+
+    def valid_number_ranges?(survey)
+      survey["fields"].each do |field|
+        next if field["type"] != "number" || valid_number_range?(field)
+
+        @post.errors.add(
+          :base,
+          I18n.t("survey.number_field_invalid_range", count: MAX_NUMBER_OPTIONS),
+        )
+        return false
+      end
+
+      true
+    end
+
+    def valid_number_range?(field)
+      min = field["min"].presence
+      max = field["max"].presence
+
+      return false if min && min !~ /\A-?\d+\z/
+      return false if max && max !~ /\A-?\d+\z/
+
+      min = (min || SurveyField::DEFAULT_NUMBER_MIN).to_i
+      max = (max || SurveyField::DEFAULT_NUMBER_MAX).to_i
+
+      min <= max && (max - min) < MAX_NUMBER_OPTIONS
     end
   end
 end

--- a/spec/lib/helper_spec.rb
+++ b/spec/lib/helper_spec.rb
@@ -138,6 +138,82 @@ describe DiscourseSurveys::Helper do
       end
     end
 
+    describe "number field validation" do
+      it "rejects a value outside the configured min/max range" do
+        survey = create_survey_from_raw(<<~MD)
+          [survey name="test"]
+          [number question="Pick a number:" min="1" max="5"]
+          [/number]
+          [/survey]
+        MD
+
+        number_field = survey.survey_fields.first
+        response = { number_field.digest => "999" }
+
+        expect {
+          DiscourseSurveys::Helper.submit_response(post.id, "test", response, user)
+        }.to raise_error(StandardError, /Pick a number:/)
+
+        expect(SurveyResponse.count).to eq(0)
+      end
+
+      it "rejects a non-numeric value" do
+        survey = create_survey_from_raw(<<~MD)
+          [survey name="test"]
+          [number question="Pick a number:" min="1" max="5"]
+          [/number]
+          [/survey]
+        MD
+
+        number_field = survey.survey_fields.first
+        response = { number_field.digest => "abc" }
+
+        expect {
+          DiscourseSurveys::Helper.submit_response(post.id, "test", response, user)
+        }.to raise_error(StandardError, /Pick a number:/)
+
+        expect(SurveyResponse.count).to eq(0)
+      end
+
+      it "accepts a value within the configured range" do
+        survey = create_survey_from_raw(<<~MD)
+          [survey name="test"]
+          [number question="Pick a number:" min="1" max="5"]
+          [/number]
+          [/survey]
+        MD
+
+        number_field = survey.survey_fields.first
+        response = { number_field.digest => "3" }
+
+        expect {
+          DiscourseSurveys::Helper.submit_response(post.id, "test", response, user)
+        }.not_to raise_error
+
+        expect(SurveyResponse.where(survey_field_id: number_field.id).first.value).to eq("3")
+      end
+
+      it "defaults to a 1-10 range when min/max are omitted" do
+        survey = create_survey_from_raw(<<~MD)
+          [survey name="test"]
+          [number question="Pick a number:"]
+          [/number]
+          [/survey]
+        MD
+
+        number_field = survey.survey_fields.first
+
+        expect {
+          DiscourseSurveys::Helper.submit_response(
+            post.id,
+            "test",
+            { number_field.digest => "11" },
+            user,
+          )
+        }.to raise_error(StandardError, /Pick a number:/)
+      end
+    end
+
     describe "valid submission" do
       it "persists responses for all fields" do
         survey = create_survey_from_raw(<<~MD)

--- a/spec/lib/survey_validator_spec.rb
+++ b/spec/lib/survey_validator_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+describe DiscourseSurveys::SurveyValidator do
+  before { SiteSetting.surveys_enabled = true }
+
+  fab!(:user)
+  fab!(:topic)
+  fab!(:post) { Fabricate(:post, topic: topic, user: user) }
+
+  def validate(raw)
+    post.raw = raw
+    described_class.new(post).validate_surveys
+  end
+
+  describe "number field range validation" do
+    it "accepts a sensible explicit range" do
+      result = validate(<<~MD)
+        [survey name="test"]
+        [number question="Pick a number:" min="1" max="10"]
+        [/number]
+        [/survey]
+      MD
+
+      expect(result).to be_truthy
+      expect(post.errors[:base]).to be_empty
+    end
+
+    it "accepts a number field with no min/max (defaults to 1-10)" do
+      result = validate(<<~MD)
+        [survey name="test"]
+        [number question="Pick a number:"]
+        [/number]
+        [/survey]
+      MD
+
+      expect(result).to be_truthy
+    end
+
+    it "rejects an extreme range that would render millions of elements" do
+      result = validate(<<~MD)
+        [survey name="test"]
+        [number question="Pick a number:" min="1" max="2147483647"]
+        [/number]
+        [/survey]
+      MD
+
+      expect(result).to eq(false)
+      expect(post.errors[:base]).to include(I18n.t("survey.number_field_invalid_range", count: 100))
+    end
+
+    it "rejects an extreme range driven only by max (min defaults to 1)" do
+      result = validate(<<~MD)
+        [survey name="test"]
+        [number question="Pick a number:" max="1000000"]
+        [/number]
+        [/survey]
+      MD
+
+      expect(result).to eq(false)
+    end
+
+    it "rejects min greater than max" do
+      result = validate(<<~MD)
+        [survey name="test"]
+        [number question="Pick a number:" min="20" max="5"]
+        [/number]
+        [/survey]
+      MD
+
+      expect(result).to eq(false)
+    end
+
+    it "rejects non-integer min/max values" do
+      result = validate(<<~MD)
+        [survey name="test"]
+        [number question="Pick a number:" min="1" max="abc"]
+        [/number]
+        [/survey]
+      MD
+
+      expect(result).to eq(false)
+    end
+
+    it "ignores min/max on non-number fields" do
+      result = validate(<<~MD)
+        [survey name="test"]
+        [textarea question="Your thoughts:" min="1" max="2147483647"]
+        [/textarea]
+        [/survey]
+      MD
+
+      expect(result).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/survey-plugin-min-max-not-implemented-nor-validated/404023

The `min` and `max` values were documented, but never used. Number fields always rendered a 1 - 10 scale, and because submitted values weren't checked server-side, a custom request could store any value.

This wires up the min & max values, includes a migration to add the new min/max columns, and adds new specs to validate. 

Existing surveys are unaffected.